### PR TITLE
fix encoding bug

### DIFF
--- a/earth_osm/gfk_data.py
+++ b/earth_osm/gfk_data.py
@@ -26,7 +26,7 @@ logger.setLevel(logging.DEBUG)
 pkg_data_dir = os.path.join(os.path.dirname(__file__), "data")
 sitemap = download_sitemap(False, pkg_data_dir)
 
-with open(sitemap) as f:
+with open(sitemap, encoding='utf8') as f:
     d = json.load(f)
 
 row_list = []


### PR DESCRIPTION
### What does this PR do?
Fixes Issue #18. Encoding needs to be defined since OS dependent. [Article](https://itecnote.com/tecnote/python-3-unicodedecodeerror-charmap-codec-cant-decode-byte-0x9d/): 


```
In Python 3, files are opened as text (decoded to Unicode) for you; you don't need to tell BeautifulSoup what codec to decode from. If decoding of the data fails, that's because you didn't tell the open() call what codec to use when reading the file; add the correct codec with an encoding argument:

with open(filename, encoding='utf8') as infile:
    html = BeautifulSoup(infile, "html.parser")

otherwise the file will be opened with your system default codec, which is OS dependent.

```

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code or workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update


